### PR TITLE
Update TabContent.tsx

### DIFF
--- a/src/components/TabContent.tsx
+++ b/src/components/TabContent.tsx
@@ -74,9 +74,14 @@ const TabContent: React.FC<TabContentProps> = ({ activeTab, queryResult, chartDa
       })();
 
       // Cleanup on tab change/unmount
-      return () => {
-        if (container) container.innerHTML = '';
-      };
+     return () => {
+       if (container) {
+         while (container.firstChild) {
+          container.removeChild(container.firstChild);
+         }
+       }
+     };
+
     }
   }, [activeTab, chartData]);
 


### PR DESCRIPTION
Before React switches the tab, this function clears everything inside #chart-container (both <canvas> and <script>).

So when the next tab content is rendered, there’s no conflicting DOM node.

It prevents React from trying to remove a node that’s already been manually removed (which caused the error).