### PR TITLE
Update TabContent.tsx

### DIFF
--- a/src/components/TabContent.tsx
+++ b/src/components/TabContent.tsx
@@ -74,13 +74,13 @@ const TabContent: React.FC<TabContentProps> = ({ activeTab, queryResult, chartDa
       })();
 
       // Cleanup on tab change/unmount
-     return () => {
-       if (container) {
-         while (container.firstChild) {
-          container.removeChild(container.firstChild);
-         }
-       }
-     };
+    return () => {
+      const container = document.getElementById('chart-container');
+      if (container && container.hasChildNodes()) {
+        container.innerHTML = '';
+      }
+    };
+
 
     }
   }, [activeTab, chartData]);


### PR DESCRIPTION
small and quick change :
1. Root cause: container or its children no longer exist at cleanup time.

2. Use document.getElementById again inside the cleanup, and guard it: