### PR TITLE
Update TabContent.tsx

### DIFF
--- a/src/components/TabContent.tsx
+++ b/src/components/TabContent.tsx
@@ -75,6 +75,16 @@ useEffect(() => {
 
   return () => {
     isMounted = false;
+
+
+  // Proper Chart.js cleanup (destroy chart instance if created)
+ const canvas = document.getElementById('myChart') as HTMLCanvasElement | null;
+  if (canvas) {
+    const ctx = canvas.getContext('2d');
+    if (ctx && (window as any).myChart instanceof Chart) {
+      (window as any).myChart.destroy();
+    }
+  }    
     const cleanupContainer = document.getElementById('chart-container');
     if (cleanupContainer) {
       cleanupContainer.innerHTML = '';


### PR DESCRIPTION
addition in cleanup logic :

Chart.js can keep running even after the DOM element is removed unless we explicitly destroy the chart instance with .destroy().

dynamically injected chart script creates window.myChart, so cleaning that up ensures no lingering memory usage or DOM manipulation happens.

This stops the chart from continuing to affect the layout after switching away from the charts tab.

